### PR TITLE
Resolve missing Moose dependency kwalitee issue

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ DBD::SQLite = 0
 DBIx::Class = 0.08108
 HTML::FormFu = 2.00
 List::MoreUtils = 0
+Moose = 0
 Storable = 0
 Task::Weaken = 0 ; make sure Scalar::Util has weaken()
 


### PR DESCRIPTION
https://cpants.cpanauthors.org/release/NIGELM/HTML-FormFu-Model-DBIC-2.02 reports:

prereq_matches_use
List all used modules in META.yml requires

Error: Moose

This small commit should prevent this by declaring Moose in dist.ini

Done as part of CPAN Pull Request Challenge.